### PR TITLE
Remove include statement

### DIFF
--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -10,8 +10,6 @@
   version="2.0"
   exclude-result-prefixes="xs dita-ot"
 >
-  <xsl:param name="BOOTSTRAP_ICONS_INCLUDE" select="'yes'"/>
-
   <xsl:template match="/|node()|@*" mode="gen-user-bootstrap-class">
     <xsl:choose>
       <xsl:when test="contains(@outputclass, 'dividered-')">

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -11,7 +11,6 @@
   exclude-result-prefixes="xs dita-ot"
 >
   <xsl:param name="BOOTSTRAP_ICONS_INCLUDE" select="'yes'"/>
-  <xsl:include href="plugin:net.infotexture.dita-bootstrap:Customization/xsl/utility-classes.xsl"/>
 
   <xsl:template match="/|node()|@*" mode="gen-user-bootstrap-class">
     <xsl:choose>


### PR DESCRIPTION
The duplicated include was adding unnecessary CSS classes as shown:

```xml
<p class="shortdesc text-body-secondary lead">
```

```xml
<p class="shortdesc text-body-secondary leadtext-body-secondary lead">
```